### PR TITLE
Template translations

### DIFF
--- a/src/FaluCli/Commands/Messages/MessagesSendCommand.cs
+++ b/src/FaluCli/Commands/Messages/MessagesSendCommand.cs
@@ -96,6 +96,9 @@ public class MessagesSendTemplatedCommand : AsbtractMessagesSendCommand
                        description: "The template alias, unique to your workspace.",
                        format: Constants.MessageTemplateAliasFormat);
 
+        this.AddOption<string>(new[] { "--language", "--lang", },
+                               description: "The language or translation to use in the template. This is represented as the ISO-639-3 code.\r\nExample: swa for Swahili or fra for French");
+
         this.AddOption(new[] { "--model", "-m", },
                        description: "The model to use with the template.\r\nExample --model '{\"name\": \"John\"}'",
                        defaultValue: "{}",

--- a/src/FaluCli/Commands/Messages/MessagesSendCommand.cs
+++ b/src/FaluCli/Commands/Messages/MessagesSendCommand.cs
@@ -33,22 +33,22 @@ public abstract class AsbtractMessagesSendCommand : Command
                                });
 
         this.AddOption(new[] { "--stream", "-s", },
-                       description: "The stream to use, either the name or unique identifier. Example: mstr_610010be9228355f14ce6e08 or transactional",
+                       description: "The stream to use, either the name or unique identifier.\r\nExample: mstr_610010be9228355f14ce6e08 or transactional",
                        defaultValue: "transactional",
                        configure: o => o.IsRequired = true);
 
         this.AddOption<Uri?>(new[] { "--media-url", },
-                             description: "Publicly accessible URL of the media to include in the message(s). Example: https://c1.staticflickr.com/3/2899/14341091933_1e92e62d12_b.jpg");
+                             description: "Publicly accessible URL of the media to include in the message(s).\r\nExample: https://c1.staticflickr.com/3/2899/14341091933_1e92e62d12_b.jpg");
 
         this.AddOption(new[] { "--media-file-id", },
-                       description: "The unique identifier of the pre-uploaded file containing the media to include in the message(s). Example: file_602a8dd0a54847479a874de4",
+                       description: "The unique identifier of the pre-uploaded file containing the media to include in the message(s).\r\nExample: file_602a8dd0a54847479a874de4",
                        format: Constants.Iso8061DurationFormat);
 
         this.AddOption<DateTimeOffset?>(new[] { "--schedule-time", "--time", },
-                                        description: $"The time at which the message(s) should be in the future. Example: {DateTime.Today.AddDays(1):O}");
+                                        description: $"The time at which the message(s) should be in the future.\r\nExample: {DateTime.Today.AddDays(1):O}");
 
         this.AddOption(new[] { "--schedule-delay", "--delay", },
-                       description: "The delay (in ISO8601 duration format) to be applied by the server before sending the message(s). Example: PT10M for 10 minutes",
+                       description: "The delay (in ISO8601 duration format) to be applied by the server before sending the message(s).\r\nExample: PT10M for 10 minutes",
                        format: Constants.Iso8061DurationFormat);
     }
 
@@ -89,7 +89,7 @@ public class MessagesSendTemplatedCommand : AsbtractMessagesSendCommand
     public MessagesSendTemplatedCommand() : base("templated", "Send a templated message.")
     {
         this.AddOption(new[] { "--id", "-i", },
-                       description: "The unique template identifier. Example: mtpl_610010be9228355f14ce6e08",
+                       description: "The unique template identifier.\r\nExample: mtpl_610010be9228355f14ce6e08",
                        format: Constants.MessageTemplateIdFormat);
 
         this.AddOption(new[] { "--alias", "-a", },
@@ -97,7 +97,7 @@ public class MessagesSendTemplatedCommand : AsbtractMessagesSendCommand
                        format: Constants.MessageTemplateAliasFormat);
 
         this.AddOption(new[] { "--model", "-m", },
-                       description: "The model to use with the template. Example --model '{\"name\": \"John\"}'",
+                       description: "The model to use with the template.\r\nExample --model '{\"name\": \"John\"}'",
                        defaultValue: "{}",
                        validate: (or) =>
                        {

--- a/src/FaluCli/Commands/Messages/MessagesSendCommandHandler.cs
+++ b/src/FaluCli/Commands/Messages/MessagesSendCommandHandler.cs
@@ -90,6 +90,7 @@ internal class MessagesSendCommandHandler : ICommandHandler
         {
             var id = context.ParseResult.ValueForOption<string>("--id");
             var alias = context.ParseResult.ValueForOption<string>("--alias");
+            var language = context.ParseResult.ValueForOption<string>("--language");
             var modelJson = context.ParseResult.ValueForOption<string>("--model")!; // marked required in the command
             var model = new MessageTemplateModel(System.Text.Json.Nodes.JsonNode.Parse(modelJson)!.AsObject());
 
@@ -107,7 +108,7 @@ internal class MessagesSendCommandHandler : ICommandHandler
                 return -1;
             }
 
-            template = new MessageCreateRequestTemplate { Id = id, Alias = alias, Model = model, };
+            template = new MessageCreateRequestTemplate { Id = id, Alias = alias, Language = language, Model = model, };
         }
         else throw new InvalidOperationException($"Command of type '{command.GetType().FullName}' is not supported here.");
 

--- a/src/FaluCli/Commands/Templates/TemplateInfo.cs
+++ b/src/FaluCli/Commands/Templates/TemplateInfo.cs
@@ -10,7 +10,7 @@ internal class TemplateInfo : IHasDescription, IHasMetadata
     public TemplateInfo(MessageTemplate template)
     {
         Alias = template.Alias;
-        Description = template.Alias;
+        Description = template.Description;
         Metadata = template.Metadata;
     }
 

--- a/src/FaluCli/Commands/Templates/TemplateManifest.cs
+++ b/src/FaluCli/Commands/Templates/TemplateManifest.cs
@@ -2,10 +2,11 @@
 
 internal class TemplateManifest
 {
-    public TemplateManifest(TemplateInfo info, string body)
+    public TemplateManifest(TemplateInfo info, string body, Dictionary<string, string> translations)
     {
         Info = info ?? throw new ArgumentNullException(nameof(info));
         Body = body ?? throw new ArgumentNullException(nameof(body));
+        Translations = translations ?? throw new ArgumentNullException(nameof(translations));
     }
 
     public TemplateInfo Info { get; }
@@ -13,6 +14,8 @@ internal class TemplateManifest
     public string? Alias => Info.Alias;
 
     public string Body { get; }
+
+    public Dictionary<string, string> Translations { get; set; }
 
     public ChangeType ChangeType { get; set; } = ChangeType.Unmodified;
 

--- a/src/FaluCli/Commands/Templates/TemplatesCommandHandler.cs
+++ b/src/FaluCli/Commands/Templates/TemplatesCommandHandler.cs
@@ -195,7 +195,9 @@ internal partial class TemplatesCommandHandler : ICommandHandler
                     Metadata = metadata,
                 };
                 logger.LogDebug("Creating template with alias {Alias} ...", alias);
-                await client.MessageTemplates.CreateAsync(request, cancellationToken: cancellationToken);
+                var response = await client.MessageTemplates.CreateAsync(request, cancellationToken: cancellationToken);
+                response.EnsureSuccess();
+                logger.LogDebug("Template with alias {Alias} created with Id: '{Id}'", alias, response.Resource!.Id);
             }
             else if (changeType is ChangeType.Modified)
             {
@@ -207,7 +209,8 @@ internal partial class TemplatesCommandHandler : ICommandHandler
                     .Replace(mt => mt.Description, description)
                     .Replace(mt => mt.Metadata, metadata);
                 logger.LogDebug("Updating template with alias {Alias} ...", alias);
-                await client.MessageTemplates.UpdateAsync(mani.Id!, patch, cancellationToken: cancellationToken);
+                var response = await client.MessageTemplates.UpdateAsync(mani.Id!, patch, cancellationToken: cancellationToken);
+                response.EnsureSuccess();
             }
         }
     }

--- a/src/FaluCli/Commands/Templates/TemplatesCommandHandler.cs
+++ b/src/FaluCli/Commands/Templates/TemplatesCommandHandler.cs
@@ -94,6 +94,10 @@ internal class TemplatesCommandHandler : ICommandHandler
             return;
         }
 
+        // delete existing file
+        if (exists) File.Delete(path);
+
+        // write to file
         using var stream = File.OpenWrite(path);
         await contents.CopyToAsync(stream, cancellationToken);
     }


### PR DESCRIPTION
Support for template translations when pulling and pushing templates and supplying language when sending templated messages.

Other changes and fixes:
- Ensure response succeeds for templates push and templates pull
- Added more debug logs for handling templates
- Assign correct value for Description in TemplateInfo
- Delete existing template file before writing a new one
- Add newlines for example values for sending messages