### PR TITLE
Collect usage telemetry via OpenTelemetry

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,8 @@ updates:
     groups:
       microsoft:
         patterns: ['Microsoft.*']
+      opentelemetry:
+        patterns: ['OpenTelemetry*']
       system:
         patterns: ['System.*']
       xunit:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -116,7 +116,7 @@ jobs:
       # https://github.blog/changelog/2023-10-30-accelerate-your-ci-cd-with-arm-based-hosted-runners-in-github-actions/
       # TODO: consider using QEMU emulator for ARM?
       if: ${{ !contains(matrix.arch, 'arm') }}
-      run: ./falu logout
+      run: ./falu logout --no-telemetry
       working-directory: ${{ github.workspace }}/drop/${{ env.DOTNET_RID }}
 
     - name: Upload Artifact (drop)

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,6 +5,7 @@
         "faluapp",
         "idempotency",
         "Mpesa",
+        "opentelemetry",
         "Xunit"
     ]
 }

--- a/src/FaluCli/Commands/Config/ConfigCommandHandler.cs
+++ b/src/FaluCli/Commands/Config/ConfigCommandHandler.cs
@@ -53,6 +53,9 @@ internal class ConfigCommandHandler(IConfigValuesProvider configValuesProvider) 
                         case "skip-update-check":
                             values.SkipUpdateChecks = bool.Parse(value);
                             break;
+                        case "no-telemetry":
+                            values.NoTelemetry = bool.Parse(value);
+                            break;
                         case "retries":
                             values.Retries = int.Parse(value);
                             break;

--- a/src/FaluCli/Config/ConfigValues.cs
+++ b/src/FaluCli/Config/ConfigValues.cs
@@ -8,6 +8,9 @@ internal record ConfigValues
     [JsonPropertyName("skip_update_checks")]
     public bool SkipUpdateChecks { get; set; }
 
+    [JsonPropertyName("no_telemetry")]
+    public bool NoTelemetry { get; set; }
+
     [JsonPropertyName("retries")]
     public int Retries { get; set; } = 0;
 

--- a/src/FaluCli/Extensions/IHostBuilderExtensions.cs
+++ b/src/FaluCli/Extensions/IHostBuilderExtensions.cs
@@ -1,10 +1,58 @@
-﻿using System.CommandLine.Hosting;
+﻿using Azure.Monitor.OpenTelemetry.Exporter;
+using Falu.Config;
+using Falu.Updates;
+using OpenTelemetry.Resources;
+using OpenTelemetry.Trace;
+using System.CommandLine.Hosting;
 using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.Extensions.Hosting;
 
 internal static class IHostBuilderExtensions
 {
+    // this value is hardcoded because Microsoft does not consider the instrumentation key sensitive
+    private const string AppInsightsConnectionString = "InstrumentationKey=05728099-c2aa-411d-8f1c-e3aa9689daae;IngestionEndpoint=https://westeurope-5.in.applicationinsights.azure.com/;LiveEndpoint=https://westeurope.livediagnostics.monitor.azure.com/;ApplicationId=bb8bb015-675d-4658-a286-5d2108ca437a";
+
+    public static IHostBuilder AddOpenTelemetry(this IHostBuilder builder, ConfigValues configValues)
+    {
+        var invocation = builder.GetInvocationContext();
+        var disabled = invocation.IsNoTelemetry() || configValues.NoTelemetry;
+        if (disabled) return builder;
+
+        builder.ConfigureServices((context, services) =>
+        {
+            var environment = context.HostingEnvironment;
+            var configuration = context.Configuration;
+            var builder = services.AddOpenTelemetry();
+
+            // configure the resource
+            builder.ConfigureResource(builder =>
+            {
+                builder.AddAttributes([new("environment", environment.EnvironmentName)]);
+
+                // add detectors
+                builder.AddDetector(new OpenTelemetry.ResourceDetectors.Host.HostDetector());
+                builder.AddDetector(new OpenTelemetry.ResourceDetectors.ProcessRuntime.ProcessRuntimeDetector());
+
+                // add service name and version (should override any existing values)
+                builder.AddService("falu-cli", serviceVersion: VersioningHelper.ProductVersion);
+            });
+
+            // add tracing
+            builder.WithTracing(tracing =>
+            {
+                tracing.AddSource("System.CommandLine");
+                tracing.AddHttpClientInstrumentation();
+
+                // add exporter to Azure Monitor
+                var aics = configuration["APPLICATIONINSIGHTS_CONNECTION_STRING"] ?? AppInsightsConnectionString;
+                tracing.AddAzureMonitorTraceExporter(options => options.ConnectionString = aics);
+            });
+        });
+
+        return builder;
+    }
+
     // this exists to work around trimming which does not keep constructors by default in the System.CommandLine.Hosting library
     // though Microsoft.Extensions.DependencyInjection does
     public static IHostBuilder UseCommandHandlerTrimmable<

--- a/src/FaluCli/Extensions/InvocationContextExtensions.cs
+++ b/src/FaluCli/Extensions/InvocationContextExtensions.cs
@@ -8,6 +8,7 @@ namespace System.CommandLine;
 internal static class InvocationContextExtensions
 {
     public static bool IsVerboseEnabled(this InvocationContext context) => context.ParseResult.ValueForOption<bool>("--verbose");
+    public static bool IsNoTelemetry(this InvocationContext context) => context.ParseResult.ValueForOption<bool>("--no-telemetry");
     public static string? GetWorkspaceId(this InvocationContext context) => context.ParseResult.ValueForOption<string>("--workspace");
     public static bool? GetLiveMode(this InvocationContext context) => context.ParseResult.ValueForOption<bool?>("--live");
 

--- a/src/FaluCli/FaluCli.csproj
+++ b/src/FaluCli/FaluCli.csproj
@@ -40,12 +40,17 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.2.0" />
     <PackageReference Include="ByteSize" Version="2.1.2" />
     <PackageReference Include="ClosedXML" Version="0.102.2" />
     <PackageReference Include="CloudNative.CloudEvents.SystemTextJson" Version="2.7.1" />
     <PackageReference Include="Falu" Version="1.13.1" />
     <PackageReference Include="FileSignatures" Version="4.4.1" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.8.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.8.1" />
+    <PackageReference Include="OpenTelemetry.ResourceDetectors.Host" Version="0.1.0-alpha.3" />
+    <PackageReference Include="OpenTelemetry.ResourceDetectors.ProcessRuntime" Version="0.1.0-alpha.3" />
     <PackageReference Include="SemanticVersioning" Version="2.0.2" />
     <PackageReference Include="Spectre.Console.Json" Version="0.49.1" />
     <PackageReference Include="System.CommandLine.Hosting" Version="0.4.0-alpha.22272.1" />

--- a/src/FaluCli/Program.cs
+++ b/src/FaluCli/Program.cs
@@ -74,6 +74,7 @@ var rootCommand = new RootCommand
 rootCommand.Description = "Official CLI tool for Falu.";
 rootCommand.AddGlobalOption(["-v", "--verbose"], "Whether to output verbosely.", false);
 rootCommand.AddGlobalOption<bool?>(["--skip-update-checks"], Res.OptionDescriptionSkipUpdateCheck); // nullable so as to allow checking if not specified
+rootCommand.AddGlobalOption<bool>(["--no-telemetry"], Res.OptionDescriptionNoTelemetry);
 
 var configValuesProvider = new ConfigValuesProvider();
 var configValues = await configValuesProvider.GetConfigValuesAsync();
@@ -123,6 +124,8 @@ var builder = new CommandLineBuilder(rootCommand)
             services.AddOpenIdProvider();
             services.AddTransient<WebsocketHandler>();
         });
+
+        host.AddOpenTelemetry(configValues);
 
         // System.CommandLine library does not create a scope, so we should skip validation of scopes
         host.UseDefaultServiceProvider(o => o.ValidateScopes = false);

--- a/src/FaluCli/Properties/Resources.Designer.cs
+++ b/src/FaluCli/Properties/Resources.Designer.cs
@@ -273,6 +273,15 @@ namespace Falu.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Whether to skip telemetry. Using this option overrides any value set in the configuration. This value can also be set globally using &apos;falu config set no-telemetry true&apos;.
+        /// </summary>
+        internal static string OptionDescriptionNoTelemetry {
+            get {
+                return ResourceManager.GetString("OptionDescriptionNoTelemetry", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The identifier of the workspace being accessed. Use this when you are logged into your account and you want to specify which workspace to target.
         ///Example: wksp_610010be9228355f14ce6e08.
         /// </summary>

--- a/src/FaluCli/Properties/Resources.resx
+++ b/src/FaluCli/Properties/Resources.resx
@@ -205,6 +205,9 @@ Example: my-awesome-op</value>
   <data name="OptionDescriptionSkipUpdateCheck" xml:space="preserve">
     <value>Whether to skip update checks. Using this option overrides any value set in the configuration. This value can also be set globally using 'falu config set skip-update-check true'</value>
   </data>
+  <data name="OptionDescriptionNoTelemetry" xml:space="preserve">
+    <value>Whether to disable telemetry collection. Using this option overrides any value set in the configuration. This value can also be set globally using 'falu config set no-telemetry true'</value>
+  </data>
   <data name="OptionDescriptionWorkspace" xml:space="preserve">
     <value>The identifier of the workspace being accessed. Use this when you are logged into your account and you want to specify which workspace to target.
 Example: wksp_610010be9228355f14ce6e08</value>


### PR DESCRIPTION
Telemetry collection can be opted out of by adding `-no-telemetry` to any command or by setting it globally using `falu config set no-telemetry true`