### PR TITLE
Sync workspaces into config

### DIFF
--- a/src/FaluCli/Client/FaluCliClient.cs
+++ b/src/FaluCli/Client/FaluCliClient.cs
@@ -1,6 +1,7 @@
 ﻿using Falu.Client.Events;
 using Falu.Client.MoneyStatements;
 using Falu.Client.Realtime;
+using Falu.Client.Workspaces;
 using Microsoft.Extensions.Options;
 
 namespace Falu.Client;
@@ -13,9 +14,11 @@ internal class FaluCliClient : FaluClient
         Events = new ExtendedEventsServiceClient(BackChannel, Options);
         MoneyStatements = new MoneyStatementsServiceClient(BackChannel, Options);
         Realtime = new RealtimeServiceClient(BackChannel, Options);
+        Workspaces = new WorkspacesServiceClient(BackChannel, Options);
     }
 
     public new ExtendedEventsServiceClient Events { get; protected set; }
     public MoneyStatementsServiceClient MoneyStatements { get; protected set; }
     public RealtimeServiceClient Realtime { get; protected set; }
+    public WorkspacesServiceClient Workspaces { get; protected set; }
 }

--- a/src/FaluCli/Client/Workspaces/Workspace.cs
+++ b/src/FaluCli/Client/Workspaces/Workspace.cs
@@ -1,0 +1,15 @@
+﻿using Falu.Core;
+
+namespace Falu.Client.Workspaces;
+
+internal class Workspace : IHasId
+{
+    /// <inheritdoc/>
+    public string? Id { get; set; }
+
+    public string? Name { get; set; }
+
+    public string? Status { get; set; }
+
+    public string? Role { get; set; }
+}

--- a/src/FaluCli/Client/Workspaces/WorkspacesListOptions.cs
+++ b/src/FaluCli/Client/Workspaces/WorkspacesListOptions.cs
@@ -1,0 +1,6 @@
+﻿using Falu.Core;
+
+namespace Falu.Client.Workspaces;
+
+/// <summary>Options for filtering and pagination of workspaces.</summary>
+public record WorkspacesListOptions : BasicListOptions { } // intentionally left blank

--- a/src/FaluCli/Client/Workspaces/WorkspacesServiceClient.cs
+++ b/src/FaluCli/Client/Workspaces/WorkspacesServiceClient.cs
@@ -1,0 +1,30 @@
+﻿using Falu.Core;
+using SC = Falu.FaluCliJsonSerializerContext;
+
+namespace Falu.Client.Workspaces;
+
+internal class WorkspacesServiceClient(HttpClient backChannel, FaluClientOptions options) : BaseServiceClient<Workspace>(backChannel, options, SC.Default.Workspace, SC.Default.ListWorkspace),
+                                                                                            ISupportsListing<Workspace, WorkspacesListOptions>
+{
+    /// <inheritdoc/>
+    protected override string BasePath => "/v1/workspaces";
+
+
+    /// <summary>Retrieve workspaces.</summary>
+    /// <inheritdoc/>
+    public virtual Task<ResourceResponse<List<Workspace>>> ListAsync(WorkspacesListOptions? options = null,
+                                                                     RequestOptions? requestOptions = null,
+                                                                     CancellationToken cancellationToken = default)
+    {
+        return ListResourcesAsync(options, requestOptions, cancellationToken);
+    }
+
+    /// <summary>Retrieve workspaces recursively.</summary>
+    /// <inheritdoc/>
+    public virtual IAsyncEnumerable<Workspace> ListRecursivelyAsync(WorkspacesListOptions? options = null,
+                                                                    RequestOptions? requestOptions = null,
+                                                                    CancellationToken cancellationToken = default)
+    {
+        return ListResourcesRecursivelyAsync(options, requestOptions, cancellationToken);
+    }
+}

--- a/src/FaluCli/Commands/Login/LogoutCommand.cs
+++ b/src/FaluCli/Commands/Login/LogoutCommand.cs
@@ -7,6 +7,7 @@ internal class LogoutCommand : FaluCliCommand
     public override Task<int> ExecuteAsync(CliCommandExecutionContext context, CancellationToken cancellationToken)
     {
         context.ConfigValues.Authentication = null;
+        context.ConfigValues.Workspaces = [];
         context.Logger.LogInformation("Authentication information cleared.");
 
         return Task.FromResult(0);

--- a/src/FaluCli/Commands/WorkspacesCommand.cs
+++ b/src/FaluCli/Commands/WorkspacesCommand.cs
@@ -1,0 +1,110 @@
+﻿using Falu.Config;
+using Spectre.Console;
+
+namespace Falu.Commands;
+
+internal class WorkspacesCommand : CliCommand
+{
+    public WorkspacesCommand() : base("workspaces", "Manage workspaces")
+    {
+        Add(new WorkspacesListCommand());
+        Add(new WorkspacesShowCommand());
+    }
+}
+
+internal class WorkspacesListCommand : FaluCliCommand
+{
+    public WorkspacesListCommand() : base("list", "Get a list of workspaces for the logged in account.\r\nBy default, 'Terminated' workspaces are not shown.")
+    {
+        this.AddOption(aliases: ["--all"],
+                       description: "List all workspaces, rather than skipping 'Terminated' ones.",
+                       defaultValue: false);
+
+        this.AddOption(aliases: ["--refresh"],
+                       description: "Retrieve up-to-date workspaces from server.",
+                       defaultValue: false);
+    }
+
+    public override async Task<int> ExecuteAsync(CliCommandExecutionContext context, CancellationToken cancellationToken)
+    {
+        var all = context.ParseResult.ValueForOption<bool>("--all");
+        var refresh = context.ParseResult.ValueForOption<bool>("--refresh");
+
+        var defaultWorkspaceId = context.ConfigValues.DefaultWorkspaceId;
+
+        var workspaces = context.ConfigValues.Workspaces.ToList();
+        if (refresh)
+        {
+            var response = await context.Client.Workspaces.ListAsync(cancellationToken: cancellationToken);
+            response.EnsureSuccess();
+            workspaces = response.Resource!.Select(w => new ConfigValuesWorkspace(w)).ToList();
+            context.ConfigValues.Workspaces = workspaces; // update them so that they are saved
+
+            // update default workspace
+            if (workspaces.Count > 0)
+            {
+                if (defaultWorkspaceId is not null)
+                {
+                    var workspace = context.ConfigValues.GetWorkspace(defaultWorkspaceId);
+                    if (workspace is null)
+                    {
+                        context.Logger.LogInformation("Default workspace '{DefaultWorkspaceId}' not found. Resetting to null.", defaultWorkspaceId);
+                        defaultWorkspaceId = context.ConfigValues.DefaultWorkspaceId = null;
+                    }
+                }
+            }
+        }
+
+        workspaces = all ? workspaces : workspaces.Where(w => !string.Equals(w.Status, "terminated", StringComparison.OrdinalIgnoreCase)).ToList();
+
+        var table = new Table().AddColumn("Name")
+                               .AddColumn("Id")
+                               .AddColumn("Status")
+                               .AddColumn(new TableColumn("Default").Centered());
+
+        foreach (var workspace in workspaces)
+        {
+            var isDefault = string.Equals(workspace.Id, defaultWorkspaceId, StringComparison.OrdinalIgnoreCase);
+            table.AddRow(new Markup(workspace.Name),
+                         new Markup(workspace.Id),
+                         new Markup(workspace.Status),
+                         new Markup(isDefault ? SpectreFormatter.ColouredGreen("✔ YES") : ""));
+        }
+
+        AnsiConsole.Write(table);
+
+        return 0;
+    }
+}
+
+internal class WorkspacesShowCommand : FaluCliCommand
+{
+    public WorkspacesShowCommand() : base("show", " Get the details of a workspace.")
+    {
+        this.AddOption<string>(aliases: ["--name", "-n"],
+                               description: "Name or ID of workspace.",
+                               configure: o => o.Required = true);
+    }
+
+    public override Task<int> ExecuteAsync(CliCommandExecutionContext context, CancellationToken cancellationToken)
+    {
+        var name = context.ParseResult.ValueForOption<string>("--name")!;
+
+        var workspace = context.ConfigValues.GetRequiredWorkspace(name);
+
+        var table = new Table().AddColumn("Name")
+                               .AddColumn("Id")
+                               .AddColumn("Status")
+                               .AddColumn(new TableColumn("Default").Centered());
+
+        var isDefault = string.Equals(workspace.Id, context.ConfigValues.DefaultWorkspaceId, StringComparison.OrdinalIgnoreCase);
+        table.AddRow(new Markup(workspace.Name),
+                     new Markup(workspace.Id),
+                     new Markup(workspace.Status),
+                     new Markup(isDefault ? SpectreFormatter.ColouredGreen("✔ YES") : ""));
+
+        AnsiConsole.Write(table);
+
+        return Task.FromResult(0);
+    }
+}

--- a/src/FaluCli/FaluCliJsonSerializerContext.cs
+++ b/src/FaluCli/FaluCliJsonSerializerContext.cs
@@ -3,6 +3,8 @@ using System.Text.Json.Serialization;
 
 namespace Falu;
 
+[JsonSerializable(typeof(List<Client.Workspaces.Workspace>))]
+
 [JsonSerializable(typeof(Events.WebhookEvent))]
 [JsonSerializable(typeof(Client.Events.EventDeliveryRetry))]
 [JsonSerializable(typeof(Client.Events.WebhookDeliveryAttempt))]

--- a/src/FaluCli/Program.cs
+++ b/src/FaluCli/Program.cs
@@ -1,6 +1,7 @@
 ﻿using Azure.Monitor.OpenTelemetry.Exporter;
 using Falu;
 using Falu.Client;
+using Falu.Commands;
 using Falu.Commands.Config;
 using Falu.Commands.Events;
 using Falu.Commands.Login;
@@ -18,6 +19,7 @@ var rootCommand = new CliRootCommand(description: "Official CLI tool for Falu.")
 {
     new LoginCommand(),
     new LogoutCommand(),
+    new WorkspacesCommand(),
 
     new EventsCommand(),
 

--- a/src/FaluCli/WorkspacedCommand.cs
+++ b/src/FaluCli/WorkspacedCommand.cs
@@ -12,7 +12,7 @@ internal abstract class WorkspacedCommand : FaluCliCommand
 
         this.AddOption(aliases: ["--workspace"],
                        description: Res.OptionDescriptionWorkspace,
-                       format: Constants.WorkspaceIdFormat);
+                       format: Constants.WorkspaceIdFormat); // TODO: allow name here and change the validation to use configValues hence update readers of the option
 
         // without this the nullable type, the option is not found because we have not migrated to the new bindings
         this.AddOption<bool?>(aliases: ["--live"],


### PR DESCRIPTION
This paves way for using the workspace name as an alternative to its identifier. It also allows us to validate the workspace before sending the request hence failing early.

The workspaces can be synced using new commands:
- `falu workspaces list [--refresh] [--all]`
- `falu workspaces show --name <name-or-id>`

After login, the workspaces are also synced which should ensure we have valid data every few (approximately 7) days.