### PR TITLE
Allow workspace name in the `--workspace` option alongside the identifier

### DIFF
--- a/src/FaluCli/Client/FaluCliClientHandler.cs
+++ b/src/FaluCli/Client/FaluCliClientHandler.cs
@@ -25,15 +25,17 @@ internal class FaluCliClientHandler(ConfigValues configValues, ParseResult parse
             if (!request.RequestUri!.ToString().Contains("/workspaces"))
             {
                 // (1a) Set the X-Workspace-Id header using the CLI option to override the default
-                if (parseResult.TryGetWorkspaceId(out var workspaceId))
+                if (parseResult.TryGetWorkspace(out var workspaceId))
                 {
-                    // TODO: check if the workspace exists in the configuration
+                    // check if the workspace exists in the configuration
+                    workspaceId = configValues.GetRequiredWorkspace(workspaceId).Id;
                 }
                 workspaceId ??= (workspaceId ?? configValues.DefaultWorkspaceId) ?? throw new FaluException(Res.MissingWorkspaceId);
                 request.Headers.Replace("X-Workspace-Id", workspaceId);
 
                 // (1b) Set the X-Live-Mode header using CLI option to override the default
-                if (parseResult.TryGetLiveMode(out var live) || (live = configValues.DefaultLiveMode) != null)
+                var live = parseResult.GetLiveMode() ?? configValues.DefaultLiveMode;
+                if (live is not null)
                 {
                     request.Headers.Replace("X-Live-Mode", live.Value.ToString().ToLowerInvariant()); // when absent, the server assumes false
                 }

--- a/src/FaluCli/Commands/Events/EventsListenCommand.cs
+++ b/src/FaluCli/Commands/Events/EventsListenCommand.cs
@@ -25,7 +25,7 @@ internal class EventsListenCommand : WorkspacedCommand
 
         this.AddOption<string[]>(["--event-type", "--type", "-t"],
                                  description: Res.OptionDescriptionEventListenEventTypes,
-                                 validate: or =>
+                                 validate: (or) =>
                                  {
                                      var values = or.GetValueOrDefault<string[]>();
                                      if (values is not null)
@@ -68,7 +68,11 @@ internal class EventsListenCommand : WorkspacedCommand
     {
         var websocketHandler = context.GetRequiredService<WebsocketHandler>();
 
-        var workspaceId = context.ParseResult.GetWorkspaceId()!;
+        if (context.ParseResult.TryGetWorkspace(out var workspaceId))
+        {
+            workspaceId = context.ConfigValues.GetRequiredWorkspace(workspaceId).Id;
+        }
+
         var live = context.ParseResult.GetLiveMode() ?? false;
         var ttl = Duration.Parse(context.ParseResult.ValueForOption<string>("--ttl")!);
         var webhookEndpointId = context.ParseResult.ValueForOption<string>("--webhook-endpoint");

--- a/src/FaluCli/Commands/RequestLogs/RequestLogsTailCommand.cs
+++ b/src/FaluCli/Commands/RequestLogs/RequestLogsTailCommand.cs
@@ -24,7 +24,7 @@ internal class RequestLogsTailCommand : WorkspacedCommand
 
         this.AddOption<string[]>(["--request-path", "--path"],
                                  description: "The request path to filter for. For example: \"/v1/messages\"",
-                                 validate: or =>
+                                 validate: (or) =>
                                  {
                                      var values = or.GetValueOrDefault<string[]>();
                                      if (values is not null)
@@ -79,7 +79,11 @@ internal class RequestLogsTailCommand : WorkspacedCommand
     {
         var websocketHandler = context.GetRequiredService<WebsocketHandler>();
 
-        var workspaceId = context.ParseResult.GetWorkspaceId()!;
+        if (context.ParseResult.TryGetWorkspace(out var workspaceId))
+        {
+            workspaceId = context.ConfigValues.GetRequiredWorkspace(workspaceId).Id;
+        }
+
         var live = context.ParseResult.GetLiveMode() ?? false;
         var ttl = Duration.Parse(context.ParseResult.ValueForOption<string>("--ttl")!);
         var ipNetworks = context.ParseResult.ValueForOption<IPNetwork[]>("--ip-network").NullIfEmpty();

--- a/src/FaluCli/Constants.cs
+++ b/src/FaluCli/Constants.cs
@@ -21,7 +21,6 @@ internal partial class Constants
     public static readonly ByteSizeLib.ByteSize MaxStatementFileSize = ByteSizeLib.ByteSize.FromKibiBytes(256);
     public static readonly string MaxStatementFileSizeString = MaxStatementFileSize.ToBinaryString();
 
-    public static readonly Regex WorkspaceIdFormat = GetWorkspaceIdFormat();
     public static readonly Regex IdempotencyKeyFormat = GetIdempotencyKeyFormat();
     public static readonly Regex ApiKeyFormat = GetApiKeyFormat();
     public static readonly Regex EventIdFormat = GetEventIdFormat();

--- a/src/FaluCli/Extensions/ParseResultExtensions.cs
+++ b/src/FaluCli/Extensions/ParseResultExtensions.cs
@@ -60,12 +60,12 @@ internal static class ParseResultExtensions
     public static bool IsNoTelemetry(this ParseResult result) => result.ValueForOption<bool>("--no-telemetry");
     public static bool IsNoUpdates(this ParseResult result) => result.ValueForOption<bool>("--no-updates");
 
-    public static string? GetWorkspaceId(this ParseResult result) => result.ValueForOption<string>("--workspace");
+    public static string? GetWorkspace(this ParseResult result) => result.ValueForOption<string>("--workspace");
     public static bool? GetLiveMode(this ParseResult result) => result.ValueForOption<bool?>("--live");
 
-    public static bool TryGetWorkspaceId(this ParseResult result, [NotNullWhen(true)] out string? workspaceId)
+    public static bool TryGetWorkspace(this ParseResult result, [NotNullWhen(true)] out string? workspaceId)
     {
-        workspaceId = result.GetWorkspaceId();
+        workspaceId = result.GetWorkspace();
         return !string.IsNullOrWhiteSpace(workspaceId);
     }
 

--- a/src/FaluCli/Properties/Resources.Designer.cs
+++ b/src/FaluCli/Properties/Resources.Designer.cs
@@ -310,7 +310,7 @@ namespace Falu.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The identifier of the workspace being accessed. Use this when you are logged into your account and you want to specify which workspace to target.
+        ///   Looks up a localized string similar to The identifier or name of the workspace being accessed. Use this when you are logged into your account and you want to specify which workspace to target.
         ///Example: wksp_610010be9228355f14ce6e08.
         /// </summary>
         internal static string OptionDescriptionWorkspace {

--- a/src/FaluCli/Properties/Resources.resx
+++ b/src/FaluCli/Properties/Resources.resx
@@ -212,7 +212,7 @@ Example: my-awesome-op</value>
     <value>Whether to disable telemetry collection. Using this option overrides any value set in the configuration. This value can also be set globally using 'falu config set no-telemetry true'</value>
   </data>
   <data name="OptionDescriptionWorkspace" xml:space="preserve">
-    <value>The identifier of the workspace being accessed. Use this when you are logged into your account and you want to specify which workspace to target.
+    <value>The identifier or name of the workspace being accessed. Use this when you are logged into your account and you want to specify which workspace to target.
 Example: wksp_610010be9228355f14ce6e08</value>
   </data>
   <data name="ProblemDetailsErrorCodeFormat" xml:space="preserve">

--- a/src/FaluCli/WorkspacedCommand.cs
+++ b/src/FaluCli/WorkspacedCommand.cs
@@ -10,9 +10,16 @@ internal abstract class WorkspacedCommand : FaluCliCommand
                        description: Res.OptionDescriptionApiKey,
                        format: Constants.ApiKeyFormat);
 
-        this.AddOption(aliases: ["--workspace"],
-                       description: Res.OptionDescriptionWorkspace,
-                       format: Constants.WorkspaceIdFormat); // TODO: allow name here and change the validation to use configValues hence update readers of the option
+        this.AddOption<string>(aliases: ["--workspace"],
+                               description: Res.OptionDescriptionWorkspace,
+                               validate: (or) =>
+                               {
+                                   var value = or.GetValueOrDefault<string>();
+                                   if (value is not null)
+                                   {
+                                       // can't validate because we do not have access to the ConfigValues here
+                                   }
+                               });
 
         // without this the nullable type, the option is not found because we have not migrated to the new bindings
         this.AddOption<bool?>(aliases: ["--live"],

--- a/tests/FaluCli.Tests/ConstantsTests.cs
+++ b/tests/FaluCli.Tests/ConstantsTests.cs
@@ -22,15 +22,6 @@ public class ConstantsTests
     }
 
     [Theory]
-    [InlineData("wksp_602cd2747409e867a240d000")]
-    [InlineData("wksp_60ffe3f79c1deb8060f91312")]
-    [InlineData("wksp_27e868O6xW4NYrQb3WvxDb8iW6D")]
-    public void WorkspaceIdFormat_IsCorrect(string input)
-    {
-        Assert.Matches(Constants.WorkspaceIdFormat, input);
-    }
-
-    [Theory]
     [InlineData("5C5F6FC9-DD6A-4C5D-A63A-DC96740CFE12")]
     [InlineData("dad11640-8f1c-4b91-8e61-051241204c8f")]
     [InlineData("pay:reload:202205091300")]


### PR DESCRIPTION
This becomes easier to use.

For example,
`falu money statements list --workspace wksp_123467890 --live`
can also be written as
`falu money statements list --workspace contoso --live`